### PR TITLE
Add purpose documentation stubs

### DIFF
--- a/src/data_pipeline/__init__.purpose.md
+++ b/src/data_pipeline/__init__.purpose.md
@@ -1,0 +1,67 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline
+- @ai-source-files: [__init__.py]
+- @ai-role: package
+- @ai-intent: "Namespace for data pipeline utilities"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: low
+- @ai-risk-performance: low
+- @ai-risk-drift: "Structure may evolve as modules are consolidated"
+- @ai-used-by: pipeline
+- @ai-downstream: 
+
+# Module: data_pipeline.__init__
+> Defines package scope for ETL and profiling helpers.
+
+---
+
+### 🎯 Intent & Responsibility
+- Expose submodules for data pulling, transformation and profiling
+- Provide a stable import path for pipeline scripts
+
+---
+
+### 📥 Inputs & 📤 Outputs
+None (package initializer)
+
+---
+
+### 🔗 Dependencies
+- None
+
+---
+
+### 🗣 Dialogic Notes
+- Currently empty; may later initialize common configs
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Package imported by various pipeline scripts
+
+#### Integration Points
+- Upstream: n/a
+- Downstream: modules within this package
+
+#### Risks
+- None
+
+---
+
+### 🧠 Tags
+@ai-role: package
+@ai-intent: module namespace
+@ai-cadence: drift-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: package
+@ai-coordination: import

--- a/src/data_pipeline/api_client.purpose.md
+++ b/src/data_pipeline/api_client.purpose.md
@@ -1,0 +1,76 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.api_client
+- @ai-source-files: [api_client.py]
+- @ai-role: client
+- @ai-intent: "Session based API client for Dentrix Ascend endpoints"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: high
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Endpoints or authentication may change"
+- @ai-used-by: data_pull
+- @ai-downstream: csv_files
+
+# Module: api_client
+> Handles authentication and HTTP requests, caching cookies to persist sessions.
+
+---
+
+### 🎯 Intent & Responsibility
+- Authenticate with Dentrix Ascend using username and password
+- Store session cookies for reuse
+- Provide GET and POST helper `make_request`
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | username | `str` | login credential |
+| 📥 In | password | `str` | login credential |
+| 📥 In | url | `str` | endpoint URL |
+| 📥 In | params/payload | `dict` | request data |
+| 📤 Out | response_json | `dict` | parsed JSON response |
+
+---
+
+### 🔗 Dependencies
+- requests
+- pickle, os, json, sys
+
+---
+
+### 🗣 Dialogic Notes
+- Exposes debugging output to `debug_output.txt`
+- Auto-relogin logic is commented out
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Utilized by data pulling scripts to fetch reports
+
+#### Integration Points
+- Upstream: user credentials
+- Downstream: `data_pull.py` storing CSVs
+
+#### Risks
+- Credentials stored in plain text in scripts
+
+---
+
+### 🧠 Tags
+@ai-role: client
+@ai-intent: session API access
+@ai-cadence: run-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: http
+@ai-coordination: polling

--- a/src/data_pipeline/bivariate_profiler.purpose.md
+++ b/src/data_pipeline/bivariate_profiler.purpose.md
@@ -1,0 +1,75 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.bivariate_profiler
+- @ai-source-files: [bivariate_profiler.py]
+- @ai-role: analysis
+- @ai-intent: "Explore relationships between pairs of variables"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: high
+- @ai-risk-drift: "Uses heavy numeric libraries; performance may vary"
+- @ai-used-by: pipeline_transformed
+- @ai-downstream: bivariate_plots
+
+# Module: bivariate_profiler
+> Provides correlation matrices, clustering metrics, logistic regression and other bivariate analyses.
+
+---
+
+### 🎯 Intent & Responsibility
+- Produce correlation heatmaps for numeric data
+- Calculate VIF, chi-squared and mutual information statistics
+- Generate pairwise scatter plots and parallel coordinates
+- Save bivariate analysis plots to a folder
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | dataframe | `pd.DataFrame` | dataset to analyze |
+| 📤 Out | figures | `List[str]` | paths to generated PNG plots |
+| 📤 Out | metrics | `dict` | computed statistics per pair |
+
+---
+
+### 🔗 Dependencies
+- pandas, numpy, seaborn, matplotlib
+- scipy, sklearn, statsmodels, geopandas
+
+---
+
+### 🗣 Dialogic Notes
+- Contains advanced analytics; may require sample size reduction for speed
+- Some functions may overlap with other profiling modules
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Typically invoked after basic profiling to analyze inter-feature relationships
+
+#### Integration Points
+- Upstream: cleaned dataset from DataTransform
+- Downstream: visualizations for reports
+
+#### Risks
+- High memory usage when computing pairwise metrics on wide datasets
+
+---
+
+### 🧠 Tags
+@ai-role: analysis
+@ai-intent: bivariate statistics
+@ai-cadence: drift-preferred
+@ai-risk-recall: high
+@ai-semantic-scope: analytics
+@ai-coordination: offline

--- a/src/data_pipeline/config.purpose.md
+++ b/src/data_pipeline/config.purpose.md
@@ -1,0 +1,67 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.config
+- @ai-source-files: [config.py]
+- @ai-role: config
+- @ai-intent: "Placeholder for pipeline configuration constants"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: low
+- @ai-risk-performance: low
+- @ai-risk-drift: "Currently empty; may be expanded"
+- @ai-used-by: pipeline
+- @ai-downstream: 
+
+# Module: config
+> Holds configuration variables used by data pulling and transformation modules.
+
+---
+
+### 🎯 Intent & Responsibility
+- Centralize API keys or file paths
+- Provide default locations for inputs and outputs
+
+---
+
+### 📥 Inputs & 📤 Outputs
+None currently
+
+---
+
+### 🔗 Dependencies
+- None
+
+---
+
+### 🗣 Dialogic Notes
+- File is empty; plan to populate with environment-specific settings
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- To be imported by ETL and pipeline scripts for shared constants
+
+#### Integration Points
+- Upstream: environment variables or config files
+- Downstream: modules referencing these constants
+
+#### Risks
+- Without content, modules may hard-code paths elsewhere
+
+---
+
+### 🧠 Tags
+@ai-role: config
+@ai-intent: placeholder settings
+@ai-cadence: drift-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: configuration
+@ai-coordination: setup

--- a/src/data_pipeline/data_pull.purpose.md
+++ b/src/data_pipeline/data_pull.purpose.md
@@ -1,0 +1,75 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.data_pull
+- @ai-source-files: [data_pull.py]
+- @ai-role: etl
+- @ai-intent: "Download reports from Dentrix Ascend API and save to CSV"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: high
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Endpoints and parameters may change"
+- @ai-used-by: pipeline
+- @ai-downstream: csv_files
+
+# Module: data_pull
+> Contains helper functions for fetching various reports and saving them locally.
+
+---
+
+### 🎯 Intent & Responsibility
+- Use `APIClient` to authenticate and fetch aged AR, statement submission, integrated payments and other reports
+- Normalize JSON responses into DataFrames
+- Write CSV files for later profiling and analysis
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | client | `APIClient` | authenticated session object |
+| 📥 In | output_dir | `str` | path to output folder |
+| 📤 Out | csv_paths | `List[str]` | saved CSV file names |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- os
+- `APIClient` from same package
+
+---
+
+### 🗣 Dialogic Notes
+- Many parameters (dates, location IDs) are hard-coded
+- Should add error handling for API failures
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Called by orchestrator scripts to refresh datasets before profiling
+
+#### Integration Points
+- Upstream: credentials provided to `APIClient`
+- Downstream: Pipeline reading the saved CSVs
+
+#### Risks
+- Rate limits or authentication errors may interrupt ETL
+
+---
+
+### 🧠 Tags
+@ai-role: etl
+@ai-intent: report download
+@ai-cadence: run-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: csv
+@ai-coordination: scheduled

--- a/src/data_pipeline/data_transform.purpose.md
+++ b/src/data_pipeline/data_transform.purpose.md
@@ -1,0 +1,75 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.data_transform
+- @ai-source-files: [data_transform.py]
+- @ai-role: transformer
+- @ai-intent: "Data cleaning utilities for pipeline use"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: low
+- @ai-risk-drift: "Duplicated with root data_transform"
+- @ai-used-by: pipeline_transformed
+- @ai-downstream: cleaned_datasets
+
+# Module: data_pipeline.data_transform
+> Provides static methods for null handling, date conversion, anonymization and joining.
+
+---
+
+### 🎯 Intent & Responsibility
+- Validate required columns exist
+- Offer column-specific null filling strategies
+- Convert date columns to pandas datetime
+- Anonymize sensitive fields by hashing
+- Merge datasets on keys with suffix handling
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | df | `pd.DataFrame` | dataset to modify |
+| 📥 In | column_strategies | `dict` | per-column null fill rules |
+| 📤 Out | df | `pd.DataFrame` | transformed dataset |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- datetime
+
+---
+
+### 🗣 Dialogic Notes
+- Mirror of top-level DataTransform; consolidation recommended
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Called after data_pull to clean raw datasets
+
+#### Integration Points
+- Upstream: CSVs from `data_pull`
+- Downstream: profilers or bivariate analysis
+
+#### Risks
+- Inconsistent logic if both transform modules diverge
+
+---
+
+### 🧠 Tags
+@ai-role: transformer
+@ai-intent: pipeline cleanup
+@ai-cadence: run-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: DataFrame
+@ai-coordination: preprocessing

--- a/src/data_pipeline/inline_html.purpose.md
+++ b/src/data_pipeline/inline_html.purpose.md
@@ -1,0 +1,73 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.inline_html
+- @ai-source-files: [inline_html.py]
+- @ai-role: utility
+- @ai-intent: "Convert external resources in HTML to inline Base64"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: low
+- @ai-risk-performance: low
+- @ai-risk-drift: "Limited error handling; environment differences may break"
+- @ai-used-by: developer
+- @ai-downstream: html_files
+
+# Module: inline_html
+> Reads an HTML file, embeds linked images as Base64, and writes a standalone HTML file.
+
+---
+
+### 🎯 Intent & Responsibility
+- Parse HTML using BeautifulSoup
+- Convert image tags referencing files into inline data URIs
+- Output a single HTML document with no external dependencies
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | input_file | `str` | path to original HTML |
+| 📤 Out | output_file | `str` | path to self-contained HTML |
+
+---
+
+### 🔗 Dependencies
+- BeautifulSoup
+- os
+- Python mimetypes module
+
+---
+
+### 🗣 Dialogic Notes
+- Useful for packaging HTML reports with embedded plots
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Standalone script, can be invoked after report generation
+
+#### Integration Points
+- Upstream: markdown or HTML report
+- Downstream: final deliverable for sharing
+
+#### Risks
+- Large images may significantly increase file size
+
+---
+
+### 🧠 Tags
+@ai-role: utility
+@ai-intent: embed resources
+@ai-cadence: run-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: html
+@ai-coordination: postprocess

--- a/src/data_pipeline/main.purpose.md
+++ b/src/data_pipeline/main.purpose.md
@@ -1,0 +1,75 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.main
+- @ai-source-files: [main.py]
+- @ai-role: orchestrator
+- @ai-intent: "Command line entry for pulling reports via APIClient"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: high
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Depends on API endpoints"
+- @ai-used-by: developer
+- @ai-downstream: csv_files
+
+# Module: data_pipeline.main
+> Authenticates with Dentrix Ascend and downloads multiple reports to a local directory.
+
+---
+
+### 🎯 Intent & Responsibility
+- Parse CLI arguments for username, password and output directory
+- Create an `APIClient`, login and load cookies
+- Call data_pull functions to fetch several reports
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | username | `str` | credential for login |
+| 📥 In | password | `str` | credential for login |
+| 📥 In | output_dir | `str` | where CSVs will be saved |
+| 📤 Out | csv_files | `List[str]` | generated CSV file paths |
+
+---
+
+### 🔗 Dependencies
+- APIClient
+- data_pull module
+- sys, os
+
+---
+
+### 🗣 Dialogic Notes
+- Credentials are passed via command line; consider environment variables
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Intended to be run manually prior to EDA pipeline
+
+#### Integration Points
+- Upstream: user credentials
+- Downstream: pipeline that profiles resulting CSVs
+
+#### Risks
+- Network or authentication failures stop the process
+
+---
+
+### 🧠 Tags
+@ai-role: orchestrator
+@ai-intent: fetch data
+@ai-cadence: run-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: CLI
+@ai-coordination: sequential

--- a/src/data_pipeline/md_to_html.purpose.md
+++ b/src/data_pipeline/md_to_html.purpose.md
@@ -1,0 +1,72 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.md_to_html
+- @ai-source-files: [md_to_html.py]
+- @ai-role: utility
+- @ai-intent: "Convert Markdown files to HTML recursively"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: low
+- @ai-risk-performance: low
+- @ai-risk-drift: "Encoding assumptions may fail on exotic characters"
+- @ai-used-by: developer
+- @ai-downstream: html_reports
+
+# Module: md_to_html
+> Walks a directory tree converting all `.md` files to `.html` using Python markdown library.
+
+---
+
+### 🎯 Intent & Responsibility
+- Accept directory path via CLI
+- Read each Markdown file with UTF-8 or fallback encoding
+- Write corresponding HTML files in place
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | directory | `str` | root folder to scan |
+| 📤 Out | html_files | `List[Path]` | created HTML file paths |
+
+---
+
+### 🔗 Dependencies
+- markdown
+- pathlib, sys
+
+---
+
+### 🗣 Dialogic Notes
+- Ignores asset references; use `inline_html` afterwards to embed images
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Optional post-processing step after report generation
+
+#### Integration Points
+- Upstream: Markdown reports from profiler
+- Downstream: shareable HTML files
+
+#### Risks
+- None significant
+
+---
+
+### 🧠 Tags
+@ai-role: utility
+@ai-intent: markdown conversion
+@ai-cadence: run-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: docs
+@ai-coordination: postprocess

--- a/src/data_pipeline/pipeline.purpose.md
+++ b/src/data_pipeline/pipeline.purpose.md
@@ -1,0 +1,75 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.pipeline
+- @ai-source-files: [pipeline.py]
+- @ai-role: orchestrator
+- @ai-intent: "Run profiling on raw CSV reports"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: low
+- @ai-risk-drift: "Hard-coded dataset paths"
+- @ai-used-by: developer
+- @ai-downstream: profiling_reports
+
+# Module: data_pipeline.pipeline
+> Entry script used to iterate over various raw data exports and generate profiles via DataProfiler.
+
+---
+
+### 🎯 Intent & Responsibility
+- Map dataset names to CSV paths and custom type hints
+- Load each dataset and instantiate DataProfiler
+- Generate markdown reports for each dataset
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | input_dir | `str` | base folder containing csv files |
+| 📤 Out | report_files | `List[str]` | generated markdown reports |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- DataProfiler
+- DataTransform (commented out)
+- os, sys
+
+---
+
+### 🗣 Dialogic Notes
+- Many dataset definitions are commented; script requires cleanup
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Designed for manual CLI execution
+- Profiles each dataset sequentially
+
+#### Integration Points
+- Upstream: csv files from API downloads
+- Downstream: analysis and visualization modules
+
+#### Risks
+- Fails if expected CSVs are missing
+
+---
+
+### 🧠 Tags
+@ai-role: orchestrator
+@ai-intent: raw data pipeline
+@ai-cadence: run-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: CLI
+@ai-coordination: sequential

--- a/src/data_pipeline/pipeline_transformed.purpose.md
+++ b/src/data_pipeline/pipeline_transformed.purpose.md
@@ -1,0 +1,74 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.pipeline_transformed
+- @ai-source-files: [pipeline_transformed.py]
+- @ai-role: orchestrator
+- @ai-intent: "Profile transformed datasets after cleaning"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: low
+- @ai-risk-drift: "Relies on specific transformed CSV names"
+- @ai-used-by: developer
+- @ai-downstream: transformed_reports
+
+# Module: pipeline_transformed
+> Similar to `pipeline.py` but expects cleaned datasets and may generate additional metrics.
+
+---
+
+### 🎯 Intent & Responsibility
+- Load cleaned CSV files from an input directory
+- Optionally profile both raw and transformed versions
+- Save markdown or HTML reports for each dataset
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | input_dir | `str` | directory of transformed CSVs |
+| 📤 Out | report_files | `List[str]` | output report paths |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- DataProfiler
+- DataTransform
+- os, sys
+
+---
+
+### 🗣 Dialogic Notes
+- Many transformation steps are commented out; structure incomplete
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Intended for manual CLI execution after transformation
+
+#### Integration Points
+- Upstream: datasets produced by separate ETL scripts
+- Downstream: bivariate analysis or report packaging
+
+#### Risks
+- Inconsistent custom_type dictionaries across datasets
+
+---
+
+### 🧠 Tags
+@ai-role: orchestrator
+@ai-intent: profiling cleaned data
+@ai-cadence: run-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: CLI
+@ai-coordination: sequential

--- a/src/data_pipeline/profiler.purpose.md
+++ b/src/data_pipeline/profiler.purpose.md
@@ -1,0 +1,71 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_pipeline.profiler
+- @ai-source-files: [profiler.py]
+- @ai-role: profiler
+- @ai-intent: "Legacy copy of profiling utilities used before refactor"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Redundant with top-level profiler"
+- @ai-used-by: pipeline
+- @ai-downstream: plots
+
+# Module: data_pipeline.profiler
+> Duplicate of root profiler module kept for backward compatibility during reorganization.
+
+---
+
+### 🎯 Intent & Responsibility
+- Provide plotting utilities and DataProfiler class similar to main module
+- Generate visualizations and profiling metrics for each column
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | dataframe | `pd.DataFrame` | dataset to profile |
+| 📤 Out | report | `str` | markdown report |
+
+---
+
+### 🔗 Dependencies
+- pandas, numpy, seaborn, matplotlib, missingno
+- os, re
+
+---
+
+### 🗣 Dialogic Notes
+- Should be consolidated with `src/profiler.py` once the reorganization stabilizes
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Invoked by `data_pipeline/pipeline.py` to generate analyses
+
+#### Integration Points
+- Upstream: CSVs loaded into DataFrames
+- Downstream: markdown or html reports
+
+#### Risks
+- Maintenance burden due to duplicated logic
+
+---
+
+### 🧠 Tags
+@ai-role: profiler
+@ai-intent: duplicated profiling module
+@ai-cadence: drift-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: dataset
+@ai-coordination: analysis

--- a/src/data_profiler.purpose.md
+++ b/src/data_profiler.purpose.md
@@ -1,0 +1,79 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_profiler
+- @ai-source-files: [data_profiler.py]
+- @ai-role: profiler
+- @ai-intent: "Generate dataset and column level profiling information"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Interface may change as profiling logic evolves"
+- @ai-used-by: pipeline,pipeline_transformed,main_pipeline,run_profiler
+- @ai-downstream: reports,plots
+
+# Module: data_profiler
+> Provides a DataProfiler class to summarize datasets and produce Markdown reports.
+
+---
+
+### 🎯 Intent & Responsibility
+- Profile overall dataset metadata
+- Analyze each column (string or numeric) for statistics and anomalies
+- Generate Markdown/HTML/CSV reports summarizing results
+- Store results in a `results` dictionary for programmatic use
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | dataframe | `pd.DataFrame` | dataset to profile |
+| 📥 In | custom_types | `dict[str,str]` | optional column type hints |
+| 📤 Out | results | `Dict[str,Any]` | nested summary of dataset and columns |
+| 📤 Out | report | `str` | Markdown/HTML/CSV text when generated |
+
+---
+
+### 🔗 Dependencies
+- pandas, numpy, seaborn, matplotlib
+- missingno
+- modules within repo: `profiler` for plotting utilities
+
+---
+
+### 🗣 Dialogic Notes
+- Current implementation mixes global helper functions and class methods.
+- Assumes small to medium data size; may require sampling for large datasets.
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Called by pipeline scripts to profile raw and transformed CSVs
+- Exposes `generate_report` for downstream consumption
+
+#### Integration Points
+- Upstream: `pipeline.py`, `main_pipeline.py`, `data_pipeline/pipeline.py`
+- Downstream: markdown reports and visual plots stored to disk
+
+#### Risks
+- Profiling large datasets may exhaust memory
+- Temporary files (plots) may accumulate
+
+---
+
+### 🧠 Tags
+@ai-role: profiler
+@ai-intent: data quality summary
+@ai-cadence: drift-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: reports
+@ai-coordination: analysis pipeline

--- a/src/data_transform.purpose.md
+++ b/src/data_transform.purpose.md
@@ -1,0 +1,78 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: data_transform
+- @ai-source-files: [data_transform.py]
+- @ai-role: transformer
+- @ai-intent: "Utility functions for cleaning and joining data"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: low
+- @ai-risk-drift: "Data types may shift depending on upstream CSV formats"
+- @ai-used-by: pipeline,main_pipeline
+- @ai-downstream: transformed_datasets
+
+# Module: data_transform
+> Provides static methods to sanitize, convert and merge DataFrames.
+
+---
+
+### 🎯 Intent & Responsibility
+- Validate required columns before transformations
+- Handle null values globally or per-column
+- Convert date strings or unix timestamps to datetime
+- Join datasets on a key and maintain suffixes
+- Optionally log operations for auditing
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | df1/df2 | `pd.DataFrame` | input dataframes |
+| 📥 In | columns | `List[str]` | column names used for transformations |
+| 📥 In | strategy | `str` | null-handling strategy ('drop','fill','median') |
+| 📤 Out | df | `pd.DataFrame` | transformed dataframe |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- datetime
+
+---
+
+### 🗣 Dialogic Notes
+- Designed as static-only; no internal state
+- Expects moderate dataset size
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Used by pipelines after profiling to clean or merge data
+- Functions can append to a log list for step tracking
+
+#### Integration Points
+- Upstream: raw DataFrames from CSVs or API pull
+- Downstream: DataProfiler for transformed datasets
+
+#### Risks
+- Incorrect column mapping may raise errors
+
+---
+
+### 🧠 Tags
+@ai-role: transformer
+@ai-intent: cleanup utilities
+@ai-cadence: run-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: DataFrame
+@ai-coordination: preprocessing

--- a/src/etl-data_from_pdf.purpose.md
+++ b/src/etl-data_from_pdf.purpose.md
@@ -1,0 +1,75 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: etl-data_from_pdf
+- @ai-source-files: [etl-data_from_pdf.py]
+- @ai-role: etl
+- @ai-intent: "Extract structured data from PDFs for later profiling"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: high
+- @ai-risk-performance: low
+- @ai-risk-drift: "Regex based extraction may fail on different PDF formats"
+- @ai-used-by: developer
+- @ai-downstream: csv,json
+
+# Module: etl-data_from_pdf
+> Utility script converting PDF invoices into structured JSON/CSV for inclusion in the EDA pipeline.
+
+---
+
+### 🎯 Intent & Responsibility
+- Open PDFs and extract raw text via `pdfplumber`
+- Parse text with regex to capture fields and line items
+- Save extracted data as JSON or CSV
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | pdf_path | `str` | path to source PDF file |
+| 📥 In | file_format | `str` | desired output format ('json' or 'csv') |
+| 📤 Out | parsed_data | `dict` | structured representation of invoice |
+| 📤 Out | output_file | `str` | path to saved JSON or CSV |
+
+---
+
+### 🔗 Dependencies
+- pdfplumber
+- pandas
+- json, re
+
+---
+
+### 🗣 Dialogic Notes
+- Intended as an example; regex patterns must be adjusted per PDF layout
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Run manually before pipeline to generate CSVs for profiling
+
+#### Integration Points
+- Upstream: raw PDF invoices
+- Downstream: pipeline scripts reading the generated CSV
+
+#### Risks
+- Parsing errors may silently drop fields
+
+---
+
+### 🧠 Tags
+@ai-role: etl
+@ai-intent: pdf extraction
+@ai-cadence: run-preferred
+@ai-risk-recall: high
+@ai-semantic-scope: invoice
+@ai-coordination: preprocessing

--- a/src/main_pipeline.purpose.md
+++ b/src/main_pipeline.purpose.md
@@ -1,0 +1,74 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: main_pipeline
+- @ai-source-files: [main_pipeline.py]
+- @ai-role: orchestrator
+- @ai-intent: "Example pipeline demonstrating profiling and transformation"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: low
+- @ai-risk-performance: low
+- @ai-risk-drift: "Demonstration script; not production ready"
+- @ai-used-by: developer
+- @ai-downstream: data_profiler,data_transform
+
+# Module: main_pipeline
+> Example script using seaborn's Titanic dataset to showcase profiling workflow.
+
+---
+
+### 🎯 Intent & Responsibility
+- Load a sample dataset (Titanic via seaborn)
+- Profile raw data using DataProfiler
+- Apply transformations via DataTransform
+- Profile transformed data and write markdown reports
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | none | | uses builtin dataset |
+| 📤 Out | reports | `List[str]` | generated markdown summaries |
+
+---
+
+### 🔗 Dependencies
+- pandas, seaborn
+- DataProfiler
+- DataTransform
+
+---
+
+### 🗣 Dialogic Notes
+- Serves as a template for customizing the pipeline
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Runs sequential steps: profile -> transform -> profile again
+
+#### Integration Points
+- Upstream: builtin dataset or user-supplied dataset
+- Downstream: Markdown reports for manual review
+
+#### Risks
+- None significant; demonstration only
+
+---
+
+### 🧠 Tags
+@ai-role: orchestrator
+@ai-intent: demonstration pipeline
+@ai-cadence: run-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: tutorial
+@ai-coordination: sequential execution

--- a/src/pipeline.purpose.md
+++ b/src/pipeline.purpose.md
@@ -1,0 +1,77 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: pipeline
+- @ai-source-files: [pipeline.py]
+- @ai-role: orchestrator
+- @ai-intent: "CLI orchestration to profile multiple CSVs"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: low
+- @ai-risk-drift: "Hard-coded file paths; may break when directory layout changes"
+- @ai-used-by: developer
+- @ai-downstream: data_profiler
+
+# Module: pipeline
+> Orchestrates DataProfiler over predefined datasets and writes reports.
+
+---
+
+### 🎯 Intent & Responsibility
+- Load CSV files from a user-specified directory
+- Apply custom type hints per dataset
+- Invoke `DataProfiler` to profile and generate markdown
+- Write resulting reports to an output directory
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | input_dir | `str` | folder containing CSV files |
+| 📥 In | output_dir | `str` | folder for report output |
+| 📤 Out | reports | `List[str]` | file paths to generated reports |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- os, sys
+- `DataProfiler` from `data_profiler`
+
+---
+
+### 🗣 Dialogic Notes
+- Contains many commented blocks and may require cleanup
+- Should decouple dataset definitions from code
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Acts as entry script when executed directly
+- Loops over dataset map and calls DataProfiler sequentially
+
+#### Integration Points
+- Upstream: CSV data prepared by ETL scripts
+- Downstream: generated markdown or HTML reports
+
+#### Risks
+- Execution may be slow for large numbers of files
+
+---
+
+### 🧠 Tags
+@ai-role: orchestrator
+@ai-intent: dataset profiling pipeline
+@ai-cadence: run-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: CLI
+@ai-coordination: sequential execution

--- a/src/profiler.purpose.md
+++ b/src/profiler.purpose.md
@@ -1,0 +1,79 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: profiler
+- @ai-source-files: [profiler.py]
+- @ai-role: profiler
+- @ai-intent: "Generate plots and advanced profiling for datasets"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Large file with experimental features"
+- @ai-used-by: data_profiler,pipeline
+- @ai-downstream: plots,markdown_reports
+
+# Module: profiler
+> Houses plotting utilities and specialized profilers for strings, numbers and temporal data.
+
+---
+
+### 🎯 Intent & Responsibility
+- Produce column charts, histograms, KDE plots, box plots and missing value matrices
+- Analyze temporal columns for gaps and trends
+- Profile strings (entropy, dominance, suspicious patterns)
+- Profile numeric columns with outlier detection
+- Provide DataProfiler class combining these analyses with visualization output
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | dataframe | `pd.DataFrame` | dataset to visualize and profile |
+| 📥 In | custom_types | `dict[str,str]` | optional mapping of column roles |
+| 📤 Out | results | `Dict[str,Any]` | metadata and per-column profiles |
+| 📤 Out | plots | `List[str]` | file paths of generated PNG images |
+
+---
+
+### 🔗 Dependencies
+- pandas, numpy, seaborn, matplotlib, missingno, scipy
+- regex, os, re
+
+---
+
+### 🗣 Dialogic Notes
+- Many plotting functions currently save directly to disk; could be decoupled
+- Temporal analysis uses heuristics for smoothing and may need tuning
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Called by `DataProfiler` to generate visual assets
+- `DataProfiler` stores paths to plots in results structure
+
+#### Integration Points
+- Upstream: DataFrames loaded from ETL steps
+- Downstream: markdown reports referencing generated plots
+
+#### Risks
+- Plot generation may be slow for wide datasets
+- Hard-coded file names may collide when running multiple times
+
+---
+
+### 🧠 Tags
+@ai-role: profiler
+@ai-intent: visualization helper
+@ai-cadence: drift-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: plots
+@ai-coordination: analysis pipeline

--- a/src/profiler_update.purpose.md
+++ b/src/profiler_update.purpose.md
@@ -1,0 +1,73 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: profiler_update
+- @ai-source-files: [profiler_update.py]
+- @ai-role: profiler
+- @ai-intent: "Alternate DataProfiler implementation with unix timestamp handling"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Parallel class may diverge from main profiler"
+- @ai-used-by: developer
+- @ai-downstream: plots
+
+# Module: profiler_update
+> Experimental variant of DataProfiler adding timestamp conversion utilities.
+
+---
+
+### 🎯 Intent & Responsibility
+- Provide enhanced preprocessing of custom data types (unix timestamps, phone numbers)
+- Profile string and numeric columns similar to primary DataProfiler
+- Intended to replace or extend existing profiler in future revisions
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | dataframe | `pd.DataFrame` | dataset to profile |
+| 📤 Out | results | `Dict[str,Any]` | profiling results with metadata |
+
+---
+
+### 🔗 Dependencies
+- pandas, numpy, seaborn, matplotlib, missingno
+- scipy.stats
+
+---
+
+### 🗣 Dialogic Notes
+- Contains partial implementations; some functions may be placeholders
+- Should be consolidated with main profiler module
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Not currently referenced by pipelines but intended as upgrade path
+
+#### Integration Points
+- Upstream: same as DataProfiler
+- Downstream: similar report generation
+
+#### Risks
+- Diverging logic may cause confusion if both profilers coexist
+
+---
+
+### 🧠 Tags
+@ai-role: profiler
+@ai-intent: experimental profiler
+@ai-cadence: drift-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: dataset
+@ai-coordination: research

--- a/src/run_profiler.purpose.md
+++ b/src/run_profiler.purpose.md
@@ -1,0 +1,73 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: run_profiler
+- @ai-source-files: [run_profiler.py]
+- @ai-role: cli
+- @ai-intent: "Simple entry script to profile local CSVs"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: low
+- @ai-risk-performance: low
+- @ai-risk-drift: "Assumes hard-coded paths to data"
+- @ai-used-by: developer
+- @ai-downstream: markdown_reports
+
+# Module: run_profiler
+> Lightweight wrapper for DataProfiler to profile predefined CSV files.
+
+---
+
+### 🎯 Intent & Responsibility
+- Load user provided CSVs from local directories
+- Invoke `DataProfiler` on each dataset
+- Save resulting markdown reports to disk
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | data_path | `str` | directory containing csv files |
+| 📤 Out | report_files | `List[str]` | paths to markdown outputs |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- DataProfiler
+- os
+
+---
+
+### 🗣 Dialogic Notes
+- Minimal script; duplicates functionality of `pipeline.py`
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Executed directly by developer for quick profiling
+
+#### Integration Points
+- Upstream: CSVs pulled from external sources
+- Downstream: Markdown reports for review
+
+#### Risks
+- Hard-coded output directories may fail if not existent
+
+---
+
+### 🧠 Tags
+@ai-role: cli
+@ai-intent: quick profiling
+@ai-cadence: run-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: CLI
+@ai-coordination: ephemeral

--- a/src/test_profiler.purpose.md
+++ b/src/test_profiler.purpose.md
@@ -1,0 +1,72 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: test_profiler
+- @ai-source-files: [test_profiler.py]
+- @ai-role: example
+- @ai-intent: "Interactive test harness for DataProfiler"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: low
+- @ai-risk-performance: low
+- @ai-risk-drift: "Contains hard-coded paths to local datasets"
+- @ai-used-by: developer
+- @ai-downstream: console_output
+
+# Module: test_profiler
+> Demonstrates running DataProfiler on local CSVs and generating example content.
+
+---
+
+### 🎯 Intent & Responsibility
+- Load CSV from developer machine
+- Execute DataProfiler and print report
+- Optionally augment documentation with dataset descriptions
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | csv_path | `str` | path to dataset |
+| 📤 Out | markdown_report | `str` | printed profiling output |
+
+---
+
+### 🔗 Dependencies
+- pandas
+- DataProfiler
+
+---
+
+### 🗣 Dialogic Notes
+- Not a real unit test; more of a manual demonstration
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Executed manually to verify profiler functionality
+
+#### Integration Points
+- Upstream: developer-supplied CSV
+- Downstream: console output or appended markdown
+
+#### Risks
+- None beyond dependency availability
+
+---
+
+### 🧠 Tags
+@ai-role: example
+@ai-intent: manual profiling test
+@ai-cadence: run-preferred
+@ai-risk-recall: low
+@ai-semantic-scope: example
+@ai-coordination: ephemeral


### PR DESCRIPTION
## Summary
- document profiling utilities and pipelines using `.purpose.md`
- outline API client and ETL modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687afb9eaff8832393ea953423d20ba4