### PR TITLE
Cleanup pipelines and outline architecture

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,30 @@
+# Architecture Overview
+
+This document captures a high level view of the data profiling pipeline based on the available modules and their `.purpose.md` descriptions.
+
+## Core Components
+
+| Module | Role | Key Purpose |
+|-------|------|-------------|
+| `data_profiler.py` | profiler | Provide dataset and column level summaries and reports |
+| `data_transform.py` | transformer | Utility functions for cleaning and joining DataFrames |
+| `profiler.py` | profiler | Advanced plotting and profiling utilities |
+| `pipeline.py` / `data_pipeline/pipeline.py` | orchestrator | CLI pipelines for running the profiler over many CSVs |
+| `main_pipeline.py` | orchestrator | Example end‑to‑end workflow using seaborn sample data |
+| `run_profiler.py` | cli | Minimal entry point for profiling a folder of CSVs |
+| `data_pipeline/*` | etl / helpers | API client, HTML conversion, and additional pipeline pieces |
+
+## Flow of Data
+
+1. **ETL and Data Pull** – Optional scripts under `data_pipeline/` fetch or extract CSVs (e.g., from PDFs or APIs).
+2. **Profiling** – The `DataProfiler` class (either `data_profiler.py` or the extended `profiler.py`) profiles DataFrames, generates visual plots, and writes markdown summaries.
+3. **Transformation** – `DataTransform` offers cleaning helpers and joins for further analysis.
+4. **Orchestration** – Pipeline scripts (`pipeline.py`, `main_pipeline.py`, etc.) load CSVs, invoke the profiler, optionally run transformations, and output reports.
+
+## Integration Notes
+
+- Results are primarily written to disk as markdown reports and PNG plots.
+- Purpose files specify upstream inputs (raw CSVs, API downloads) and downstream artifacts (reports, plots).
+- CLI entry points accept an input directory of CSVs and an output directory for results.
+
+This overview will evolve as modules are refined and coordinated into a cohesive package.

--- a/src/data_pipeline/pipeline.py
+++ b/src/data_pipeline/pipeline.py
@@ -5,7 +5,8 @@ from data_transform import DataTransform
 import sys
 from collections import defaultdict
 
-def load_csv_files(name, path):
+def load_csv_files(file_paths):
+    """Load multiple CSV files into a dictionary keyed by filename."""
     dataframes = {}
     for file_path in file_paths:
         df_name = os.path.basename(file_path).replace(".csv", "")

--- a/src/data_pipeline/pipeline_transformed.py
+++ b/src/data_pipeline/pipeline_transformed.py
@@ -4,7 +4,8 @@ from profiler import DataProfiler
 from data_transform import DataTransform
 import sys
 
-def load_csv_files(name, path):
+def load_csv_files(file_paths):
+    """Load multiple CSV files into a dictionary keyed by filename."""
     dataframes = {}
     for file_path in file_paths:
         df_name = os.path.basename(file_path).replace(".csv", "")

--- a/src/data_profiler.py
+++ b/src/data_profiler.py
@@ -54,7 +54,9 @@ class DataProfiler:
         # Implement phone number parsing logic here
         return value  # Placeholder implementation   
 
+    @staticmethod
     def profile_phone_numbers(df, phone_column):
+        """Return counts of valid and invalid phone numbers in a column."""
         valid_count = 0
         invalid_count = 0
         for number in df[phone_column]:
@@ -77,6 +79,7 @@ class DataProfiler:
         except Exception as e:
             self.results["dataset_metadata"] = {"error": str(e)}
     
+    @staticmethod
     def detect_outliers(series, method='iqr'):
         if method == 'iqr':
             q1 = series.quantile(0.25)

--- a/src/main_pipeline.py
+++ b/src/main_pipeline.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     print("Profiling raw data...")
     raw_profiler = DataProfiler(df_raw)
     raw_profiler.profile_dataset()
-    raw_profiler.generate_markdown_report("raw_data_profile.md")
+    raw_profiler.generate_report(format="markdown", output_filename="raw_data_profile.md")
 
     # Step 2: Clean and transform data
     print("Transforming data...")
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     print("Profiling transformed data...")
     transformed_profiler = DataProfiler(df_transformed)
     transformed_profiler.profile_dataset()
-    transformed_profiler.generate_markdown_report("transformed_data_profile.md")
+    transformed_profiler.generate_report(format="markdown", output_filename="transformed_data_profile.md")
 
     # Final output
     print("Pipeline execution complete. Reports generated.")

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -4,7 +4,8 @@ from profiler import DataProfiler
 from data_transform import DataTransform
 import sys
 
-def load_csv_files(name, path):
+def load_csv_files(file_paths):
+    """Load multiple CSV files into a dictionary keyed by filename."""
     dataframes = {}
     for file_path in file_paths:
         df_name = os.path.basename(file_path).replace(".csv", "")


### PR DESCRIPTION
## Summary
- fix helper function signatures in pipeline modules
- update main pipeline to call `generate_report`
- add static helper methods to `DataProfiler`
- document repository structure in `ARCHITECTURE_OVERVIEW.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687bedbbeb208323a843a7eeb8dbcc26