### PR TITLE
Add Typer CLI for config-driven profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Run the CLI pipeline on a folder of CSV files:
 ```bash
 python src/pipeline.py <input_dir> <output_dir>
 ```
-Individual profiling can be executed with:
+Individual profiling can now be run via a Typer CLI:
 ```bash
-python src/run_profiler.py
+python src/typer_cli.py profile config.yml
 ```
 The main pipelines now import `DataProfiler` from `data_profiler` after consolidation.
 Example notebooks and templates are provided under `templates/`.

--- a/purpose_files/typer_cli.purpose.md
+++ b/purpose_files/typer_cli.purpose.md
@@ -1,0 +1,80 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: typer_cli
+- @ai-source-files: [src/typer_cli.py]
+- @ai-role: cli
+- @ai-intent: "Typer-based interface for running DataProfiler via config"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: medium
+- @ai-risk-drift: "Config schema may evolve"
+- @ai-used-by: developer
+- @ai-downstream: data_profiler
+
+# Module: typer_cli
+> Command line entry point loading YAML/JSON configuration to orchestrate dataset profiling.
+
+---
+
+### 🎯 Intent & Responsibility
+- Parse config containing dataset paths, field selections, and type hints
+- Instantiate `DataProfiler` and `BivariateProfiler` as requested
+- Write profiling reports to an output directory in chosen format
+- Expose flexible options for which analyses to execute
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | config | `Path` | YAML/JSON config file |
+| 📥 In | output_dir | `Path` | destination folder for reports |
+| 📥 In | analyses | `List[str]` | selected analysis steps |
+| 📤 Out | reports | `List[str]` | generated report file paths |
+
+---
+
+### 🔗 Dependencies
+- `typer`, `pyyaml`
+- `pandas`
+- `DataProfiler`
+- `BivariateProfiler`
+
+---
+
+### 🗣 Dialogic Notes
+- API keys from config are currently unused but reserved for future features
+- Bivariate analysis supports predefined column pairs
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Invoked manually via `python src/typer_cli.py profile <config>`
+- For each dataset, sequentially runs profiling and optional bivariate plots
+
+#### Integration Points
+- Upstream: configuration files with dataset info
+- Downstream: markdown or HTML reports written to disk
+
+#### Risks
+- Misconfigured paths cause runtime errors
+- Large datasets may impact performance
+
+---
+
+### 🧠 Tags
+@ai-role: cli
+@ai-intent: config-driven profiling
+@ai-cadence: run-preferred
+@ai-risk-recall: medium
+@ai-semantic-scope: CLI
+@ai-coordination: sequential

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ dependencies = [
   "beautifulsoup4",
   "python-magic",
   "markdown",
-  "pdfplumber"
+  "pdfplumber",
+  "typer",
+  "pyyaml"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ beautifulsoup4
 python-magic
 markdown
 pdfplumber
+
+typer
+pyyaml

--- a/src/typer_cli.py
+++ b/src/typer_cli.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import pandas as pd
+import typer
+import yaml
+
+from data_profiler import DataProfiler
+from data_pipeline.bivariate_profiler import BivariateProfiler
+
+app = typer.Typer(help="Run data profiling based on a configuration file.")
+
+
+def load_config(path: Path) -> dict:
+    """Load YAML or JSON configuration."""
+    with open(path, "r") as f:
+        if path.suffix in {".yaml", ".yml"}:
+            return yaml.safe_load(f)
+        return json.load(f)
+
+
+@app.command()
+def profile(
+    config: Path = typer.Argument(..., help="Path to YAML/JSON configuration."),
+    output_dir: Path = typer.Option(Path("output"), help="Directory for reports"),
+    format: str = typer.Option("markdown", help="Report format: markdown/html/csv"),
+    analyses: List[str] = typer.Option(
+        ["dataset", "columns"],
+        help="Analyses to run: dataset, columns, bivariate",
+    ),
+) -> None:
+    """Run profiling for datasets defined in the configuration."""
+    cfg_path = config.resolve()
+    cfg = load_config(cfg_path)
+
+    api_key = cfg.get("api_key")  # Currently unused
+    datasets = cfg.get("datasets", {})
+
+    for name, ds in datasets.items():
+        path = Path(ds["path"])
+        if not path.is_absolute():
+            path = (cfg_path.parent / path).resolve()
+        df = pd.read_csv(path)
+
+        fields: Optional[List[str]] = ds.get("fields")
+        if fields:
+            df = df[fields]
+
+        types = ds.get("types", {})
+
+        profiler = DataProfiler(df, custom_types=types)
+        if "dataset" in analyses:
+            profiler.profile_dataset()
+        if "columns" in analyses:
+            profiler.profile_columns()
+
+        report = profiler.generate_report(format, dataset=name)
+
+        out_dir = (output_dir / name).resolve()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        ext = "md" if format == "markdown" else format
+        with open(out_dir / f"{name}_report.{ext}", "w") as f:
+            f.write(report)
+
+        if "bivariate" in analyses:
+            pairs = ds.get("bivariate_pairs", [])
+            bivariate = BivariateProfiler(df, output_dir=str(out_dir / "bivariate"))
+            if pairs:
+                for p in pairs:
+                    if len(p) == 2:
+                        bivariate.scatter_plot(p[0], p[1])
+            bivariate.correlation_analysis()
+
+    typer.echo("Profiling complete.")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- create `typer_cli.py` implementing a Typer-based interface for DataProfiler
- document CLI usage in README
- include new `typer_cli.purpose.md`
- add `typer` and `pyyaml` as dependencies

## Testing
- `python -m py_compile src/typer_cli.py`
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_687ea78ca6e88323a30ca315ad8018f7