### PR TITLE
Introduce Typer-based CLI for DataProfiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Run the CLI pipeline on a folder of CSV files:
 ```bash
 python src/pipeline.py <input_dir> <output_dir>
 ```
-Individual profiling can be executed with:
+Individual profiling can be executed with the Typer CLI:
 ```bash
-python src/run_profiler.py
+python src/profiler_cli.py profile --config my_config.json --output-dir reports
 ```
 The main pipelines now import `DataProfiler` from `data_profiler` after consolidation.
 Example notebooks and templates are provided under `templates/`.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -13,7 +13,10 @@ This guide outlines common workflows for generating Data Guides.
    Reports and plots are written to the specified output directory.
 
 3. **Custom Profiling**
-   - Use `DataProfiler` directly for single DataFrames.
-   - Results can be converted to markdown via `generate_report()`.
+   - Run the Typer CLI with a config file:
+   ```bash
+   python src/profiler_cli.py profile --config my_config.json --output-dir reports
+   ```
+   - You can also use `DataProfiler` directly for single DataFrames and call `generate_report()`.
 
 See the template in `templates/data_guide_template.md` for report structure.

--- a/purpose_files/profiler_cli.purpose.md
+++ b/purpose_files/profiler_cli.purpose.md
@@ -1,0 +1,79 @@
+# @codex-role: architect
+# @codex-objective: generate or upgrade `.purpose.md` with:
+# - output schema
+# - coordination logic
+# - integration points
+# - ecosystem anchoring
+# Follow AGENTS.md G-10 and Section 9 enrichment instructions.
+- @ai-path: profiler_cli
+- @ai-source-files: [profiler_cli.py]
+- @ai-role: cli
+- @ai-intent: "Typer-based interface for running DataProfiler using config files"
+- @ai-version: 0.1.0
+- @ai-generated: true
+- @ai-verified: false
+- @schema-version: 0.3
+- @ai-risk-pii: medium
+- @ai-risk-performance: low
+- @ai-risk-drift: "Config schema may evolve with GUI integration"
+- @ai-used-by: developer
+- @ai-downstream: reports,plots
+
+# Module: profiler_cli
+> Command line entrypoint using Typer to profile datasets defined in JSON/YAML configs.
+
+---
+
+### 🎯 Intent & Responsibility
+- Parse configuration files providing dataset paths, field selections and type hints
+- Invoke `DataProfiler` for univariate analysis and optional `BivariateProfiler`
+- Write markdown or HTML reports to a specified output directory
+
+---
+
+### 📥 Inputs & 📤 Outputs
+| Direction | Name | Type | Description |
+|-----------|------|------|-------------|
+| 📥 In | config | `List[Path]` | paths to JSON/YAML configuration files |
+| 📥 In | analyses | `List[str]` | names of analyses to run (`univariate`, `bivariate`) |
+| 📤 Out | reports | `List[str]` | generated report file paths |
+| 📤 Out | plots | `List[str]` | images from bivariate analysis |
+
+---
+
+### 🔗 Dependencies
+- Typer
+- pandas
+- DataProfiler, BivariateProfiler
+- optional `PyYAML` for YAML configs
+
+---
+
+### 🗣 Dialogic Notes
+- Designed for CLI usage ahead of planned GUI
+- Accepts absolute or relative paths for flexible integration
+
+---
+
+### 9 Pipeline Integration
+#### Coordination Mechanics
+- Executed by developers to profile datasets via config-driven inputs
+- Loops through datasets and pair definitions from config
+
+#### Integration Points
+- Upstream: configuration files created manually or by other tools
+- Downstream: profiling reports and bivariate plots for further analysis
+
+#### Risks
+- Config schema not yet finalized
+- Large datasets may slow execution
+
+---
+
+### 🧠 Tags
+@ai-role: cli
+@ai-intent: config-driven profiler
+@ai-cadence: run
+@ai-risk-recall: medium
+@ai-semantic-scope: CLI
+@ai-coordination: sequential execution

--- a/src/profiler_cli.py
+++ b/src/profiler_cli.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import pandas as pd
+import typer
+
+from data_profiler import DataProfiler
+from data_pipeline.bivariate_profiler import BivariateProfiler
+
+app = typer.Typer(help="Data Profiler command line interface")
+
+
+def _load_config(path: Path) -> dict:
+    """Load a JSON or YAML config file."""
+    with path.open() as f:
+        if path.suffix.lower() in {".yml", ".yaml"}:
+            try:
+                import yaml  # type: ignore
+            except Exception as exc:
+                raise typer.BadParameter("PyYAML required for YAML configs") from exc
+            return yaml.safe_load(f)
+        return json.load(f)
+
+
+@app.command()
+def profile(
+    config: List[Path] = typer.Option(..., "--config", "-c", help="Path(s) to config file(s)"),
+    output_dir: Path = typer.Option(Path("output"), "--output-dir", "-o", help="Directory for reports"),
+    analyses: List[str] = typer.Option(["univariate"], "--analysis", "-a", help="Analyses to run"),
+    report_format: str = typer.Option("markdown", "--format", "-f", help="Report format: markdown or html"),
+) -> None:
+    """Run profiling using the provided configuration."""
+
+    for cfg_path in config:
+        cfg = _load_config(cfg_path)
+        api_key = cfg.get("api_key")  # currently unused but parsed for future use
+        datasets = cfg.get("datasets", {})
+        bivariate_pairs = cfg.get("bivariate_pairs", [])
+
+        for name, ds in datasets.items():
+            csv_path = Path(ds["path"]).resolve()
+            df = pd.read_csv(csv_path)
+
+            if "fields" in ds:
+                df = df[ds["fields"]]
+
+            output_subdir = output_dir / name
+            output_subdir.mkdir(parents=True, exist_ok=True)
+
+            profiler = DataProfiler(df, custom_types=ds.get("types"), output_dir=str(output_subdir))
+
+            if "univariate" in analyses:
+                profiler.profile_dataset()
+                profiler.profile_columns()
+                ext = "md" if report_format == "markdown" else report_format
+                report = profiler.generate_report(report_format, output_filename=f"{name}_profile.{ext}")
+                (output_subdir / f"{name}_profile.{ext}").write_text(report)
+
+            if "bivariate" in analyses and bivariate_pairs:
+                bivariate = BivariateProfiler(df, output_dir=str(output_subdir / "bivariate"))
+                bivariate.correlation_analysis()
+                for pair in bivariate_pairs:
+                    if len(pair) != 2:
+                        continue
+                    x, y = pair
+                    if x in df.columns and y in df.columns:
+                        bivariate.scatter_plot(x, y)
+
+
+if __name__ == "__main__":
+    app()
+


### PR DESCRIPTION
## Summary
- add `profiler_cli.py` using Typer to run profiling from JSON/YAML configs
- document new CLI usage in README and Usage Guide
- include `.purpose.md` for the new module

## Testing
- `python -m pip install -e .`
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_687ea78ca6e88323a30ca315ad8018f7